### PR TITLE
Securely store and manage encryption key

### DIFF
--- a/Nuri/Nuri/Sources/Services/PasskeyAuthenticationService.swift
+++ b/Nuri/Nuri/Sources/Services/PasskeyAuthenticationService.swift
@@ -94,6 +94,7 @@ final class PasskeyAuthenticationService: NSObject {
         let verified: Bool
         let username: String?
         let isAnonymous: Bool
+        let encryptionKey: String? // Base-64 encoded 32-byte AES key
     }
     
     struct RegistrationOptionsResponse: Codable {
@@ -147,6 +148,7 @@ final class PasskeyAuthenticationService: NSObject {
         let verified: Bool
         let username: String?
         let isAnonymous: Bool
+        let encryptionKey: String? // Base-64 encoded 32-byte AES key (only on first registration)
     }
     
     // MARK: - Main Authentication Flow
@@ -382,6 +384,16 @@ final class PasskeyAuthenticationService: NSObject {
         
         do {
             let verificationResponse = try JSONDecoder().decode(AuthenticationVerificationResponse.self, from: data)
+
+            // Configure encryption service if server supplied a key
+            if let keyBase64 = verificationResponse.encryptionKey {
+                do {
+                    try SimpleEncryptionService.shared.configure(withBase64Key: keyBase64)
+                } catch {
+                    Log.passkey.error("Failed to configure encryption key", error: error)
+                }
+            }
+
             Log.passkey.success("Verification successful", metadata: [
                 "verified": verificationResponse.verified,
                 "username": verificationResponse.username ?? "anonymous",
@@ -456,6 +468,13 @@ final class PasskeyAuthenticationService: NSObject {
         }
         
         let verificationResponse = try JSONDecoder().decode(RegistrationVerificationResponse.self, from: data)
+        if let keyBase64 = verificationResponse.encryptionKey {
+            do {
+                try SimpleEncryptionService.shared.configure(withBase64Key: keyBase64)
+            } catch {
+                Log.passkey.error("Failed to configure encryption key", error: error)
+            }
+        }
         return (verificationResponse.verified, verificationResponse.username)
     }
     

--- a/Nuri/Nuri/Sources/Services/SimpleEncryptionService.swift
+++ b/Nuri/Nuri/Sources/Services/SimpleEncryptionService.swift
@@ -1,120 +1,131 @@
 import Foundation
 import CryptoKit
 
-/// Simple password-based encryption for testing
+/// A per-user AES-GCM encryption helper. The symmetric key is provisioned by the
+/// passkey backend after successful authentication/registration and **must** be
+/// configured before any encryption/decryption operation is attempted.
+///
+/// The former test-password workflow is retained as a *no-op* so that existing
+/// debug UI continues to compile, but encryption can only proceed once a real
+/// key has been set.
 final class SimpleEncryptionService {
     static let shared = SimpleEncryptionService()
-    
-    // EDITABLE PASSWORD FOR TESTING - can be changed via security screen
-    private var testPassword = "nuri-test-password-2024"
-    
+
+    // MARK: ‑ Private state
+    /// The symmetric AES key supplied by the backend. `nil` until the user has
+    /// authenticated with their passkey and the key was delivered.
+    private var symmetricKey: SymmetricKey?
+
+    /// Retains the raw base-64 string for optional debugging/diagnostics.
+    private var rawKeyBase64: String?
+
     private init() {
-        print("🔐 [SimpleEncryptionService] Initialized with test password: \(testPassword)")
+        print("🔐 [SimpleEncryptionService] Initialized – waiting for remote key…")
     }
-    
-    /// Get current password for display/editing
+
+    // MARK: ‑ Configuration
+    /// Configure the service with a base64-encoded key received from the
+    /// backend.
+    func configure(withBase64Key base64Key: String) throws {
+        guard let keyData = Data(base64Encoded: base64Key) else {
+            throw EncryptionError.invalidBase64
+        }
+        guard keyData.count == 32 else {
+            print("⚠️ [SimpleEncryptionService] Unexpected key length (expected 32 bytes, got \(keyData.count)) – continuing anyway.")
+        }
+
+        self.symmetricKey = SymmetricKey(data: keyData)
+        self.rawKeyBase64 = base64Key
+
+        print("✅ [SimpleEncryptionService] Configured with remote AES key (length: \(keyData.count) bytes)")
+    }
+
+    /// Indicates whether the service is ready for crypto operations.
+    var isConfigured: Bool { symmetricKey != nil }
+
+    // MARK: ‑ Public helpers retained for legacy debug UI
+    /// Deprecated – kept so existing debug UI compiles. Always returns a short
+    /// description of the current configuration state instead of a password.
     func getCurrentPassword() -> String {
-        return testPassword
+        if let rawKeyBase64 {
+            return "<REMOTE AES KEY – \(rawKeyBase64.prefix(8))…>"
+        } else {
+            return "<NO KEY CONFIGURED>"
+        }
     }
-    
-    /// Set new password for testing
+
+    /// Deprecated – no-op retained for source compatibility with `SecurityView`.
     func setPassword(_ newPassword: String) {
-        print("🔐 [SimpleEncryptionService] Password changed from '\(testPassword)' to '\(newPassword)'")
-        testPassword = newPassword
+        print("⚠️ [SimpleEncryptionService] setPassword(_:) called – ignored. Remote keys are managed automatically.")
     }
-    
-    /// Encrypt data using hardcoded password
+
+    // MARK: ‑ Encryption / Decryption
     func encrypt(data: String) throws -> String {
-        print("🔐 [SimpleEncryptionService] Encrypting data with test password...")
-        
+        guard let key = symmetricKey else {
+            throw EncryptionError.keyNotConfigured
+        }
+
+        print("🔐 [SimpleEncryptionService] Encrypting data using remote AES key…")
+
         guard let dataToEncrypt = data.data(using: .utf8) else {
             throw EncryptionError.dataConversionFailed
         }
-        
-        // Derive key from password
-        let key = deriveKey(from: testPassword)
-        
-        // Encrypt with AES-GCM
+
         let sealedBox = try AES.GCM.seal(dataToEncrypt, using: key)
-        
-        // Return base64 encoded result
         let encryptedData = sealedBox.combined!
         let result = encryptedData.base64EncodedString()
-        
-        print("   ✅ Data encrypted successfully")
-        print("   📝 Input length: \(data.count) chars")
-        print("   📝 Output length: \(result.count) chars")
-        
+
+        print("   ✅ Data encrypted successfully (cipher length: \(result.count) chars)")
+
         return result
     }
-    
-    /// Decrypt data using hardcoded password
+
     func decrypt(encryptedBase64: String) throws -> String {
-        print("🔓 [SimpleEncryptionService] Decrypting data with test password...")
-        
+        guard let key = symmetricKey else {
+            throw EncryptionError.keyNotConfigured
+        }
+
+        print("🔓 [SimpleEncryptionService] Decrypting data using remote AES key…")
+
         guard let encryptedData = Data(base64Encoded: encryptedBase64) else {
             throw EncryptionError.invalidBase64
         }
-        
-        // Derive same key from password
-        let key = deriveKey(from: testPassword)
-        
-        // Decrypt with AES-GCM
+
         let sealedBox = try AES.GCM.SealedBox(combined: encryptedData)
         let decryptedData = try AES.GCM.open(sealedBox, using: key)
-        
+
         guard let result = String(data: decryptedData, encoding: .utf8) else {
             throw EncryptionError.dataConversionFailed
         }
-        
-        print("   ✅ Data decrypted successfully")
-        print("   📝 Input length: \(encryptedBase64.count) chars")
-        print("   📝 Output length: \(result.count) chars")
-        
+
+        print("   ✅ Data decrypted successfully (plain length: \(result.count) chars)")
+
         return result
     }
-    
-    /// Test encryption/decryption roundtrip
+
+    /// Simple round-trip test for debugging.
     func testRoundtrip(testData: String) -> String {
-        print("🧪 [SimpleEncryptionService] Testing encryption roundtrip...")
-        
         do {
-            // Encrypt
             let encrypted = try encrypt(data: testData)
-            print("   ✅ Encryption successful")
-            
-            // Decrypt
             let decrypted = try decrypt(encryptedBase64: encrypted)
-            print("   ✅ Decryption successful")
-            
-            // Verify
-            let matches = testData == decrypted
-            print("   🔍 Data matches: \(matches)")
-            
+            let matches = (testData == decrypted)
             return """
             🧪 ENCRYPTION ROUNDTRIP TEST:
-            
+
             ✅ Original: \(testData)
             🔐 Encrypted: \(encrypted.prefix(50))...
             🔓 Decrypted: \(decrypted)
             🎯 Match: \(matches ? "✅ SUCCESS" : "❌ FAILED")
             """
-            
         } catch {
             return "❌ Roundtrip test failed: \(error)"
         }
     }
-    
-    private func deriveKey(from password: String) -> SymmetricKey {
-        // Simple key derivation from password
-        // In production, use PBKDF2 or similar
-        let data = password.data(using: .utf8)!
-        let hash = SHA256.hash(data: data)
-        return SymmetricKey(data: hash)
-    }
-    
+
+    // MARK: ‑ Error types
     enum EncryptionError: Error {
         case dataConversionFailed
         case invalidBase64
+        case keyNotConfigured
     }
 }


### PR DESCRIPTION
Refactor encryption to use a unique, per-user AES key provided by the backend, replacing the hardcoded client-side password.

This change enhances security by ensuring each user's wallet backup encryption/decryption relies on a dynamically generated 32-byte AES key. This key is returned by the passkey backend upon successful authentication or registration and is then used to configure the `SimpleEncryptionService`. The previous hardcoded password approach is removed, while existing `encrypt`/`decrypt` calls remain functional, now powered by the new per-user key.

---

[Open in Web](https://cursor.com/agents?id=bc-73d9a7d9-95e5-46a3-a1f9-a0a9e063c308) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-73d9a7d9-95e5-46a3-a1f9-a0a9e063c308) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)